### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@
 欢迎加入我们的钉钉公开群，与我们一起探讨 AI 技术。钉钉群号：36165029092
 
 <img src="./docs/img/dingding_group3.png" alt="store" width="500"/>
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/aliyun-alibabacloud-tablestore-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/aliyun-alibabacloud-tablestore-mcp-server).